### PR TITLE
fix: Add deprecatedTag to events

### DIFF
--- a/fixtures/components/deprecated-tag/example/index.tsx
+++ b/fixtures/components/deprecated-tag/example/index.tsx
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import * as React from 'react';
+import { NonCancelableEventHandler } from '../../internal/events';
 
 export interface ExampleProps {
   /**
@@ -22,12 +23,19 @@ export interface ExampleProps {
    * @deprecated This slot is not supported.
    */
   children?: React.ReactNode;
+
+  /**
+   * Fired when the user clicks the button.
+   * @deprecated This event handler is not supported.
+   */
+  onButtonClick?: NonCancelableEventHandler;
 }
 
-export default function Example({ header, className, children }: ExampleProps) {
+export default function Example({ header, className, children, onButtonClick }: ExampleProps) {
   return (
     <div className={className}>
       <header>{header}</header>
+      <button onClick={onButtonClick}>A Button</button>
       {children}
     </div>
   );

--- a/src/components/build-definition.ts
+++ b/src/components/build-definition.ts
@@ -25,6 +25,7 @@ function buildEventInfo(handler: DeclarationReflection) {
     cancelable: handler.type.name !== 'NonCancelableEventHandler',
     detailType: typeName,
     detailInlineType: typeDefinition,
+    deprecatedTag: handler.comment?.tags?.find(tag => tag.tagName === 'deprecated')?.text.trim(),
   };
 }
 

--- a/test/components/deprecated-tag.test.ts
+++ b/test/components/deprecated-tag.test.ts
@@ -44,4 +44,14 @@ test('should have correct region and properties definitions', () => {
       visualRefreshTag: undefined,
     },
   ]);
+  expect(component.events).toEqual([
+    {
+      deprecatedTag: 'This event handler is not supported.',
+      description: 'Fired when the user clicks the button.',
+      name: 'onButtonClick',
+      cancelable: false,
+      detailType: undefined,
+      detailInlineType: undefined,
+    },
+  ]);
 });


### PR DESCRIPTION
Deprecated tag is not shown in Events definition in component API tab. For example, `onButtonClick` of Alert is deprecated but is not shown on website https://cloudscape.design/components/alert/?tabId=api. The PR is to add deprecatedTag to events. 
Tested locally on website
<img width="1003" alt="Screenshot 2023-03-02 at 15 46 31" src="https://user-images.githubusercontent.com/98534165/222461552-03db85f4-23da-4777-b2ad-e6cc697798e2.png">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
