### PR TITLE
feat: Add ability to annotate properties and slots with @i18n

### DIFF
--- a/fixtures/components/i18n-tag/example/index.tsx
+++ b/fixtures/components/i18n-tag/example/index.tsx
@@ -1,0 +1,32 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import * as React from 'react';
+
+export interface ExampleProps {
+  /**
+   * Header
+   * @i18n
+   */
+  header?: string;
+
+  /**
+   * Adds the specified classes to the root element of the component.
+   */
+  className?: string;
+
+  /**
+   * Main content
+   * @displayname content
+   * @i18n Special instructions
+   */
+  children?: React.ReactNode;
+}
+
+export default function Example({ header, className, children }: ExampleProps) {
+  return (
+    <div className={className}>
+      <header>{header}</header>
+      {children}
+    </div>
+  );
+}

--- a/fixtures/components/i18n-tag/tsconfig.json
+++ b/fixtures/components/i18n-tag/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["./**/*.tsx"]
+}

--- a/src/components/build-definition.ts
+++ b/src/components/build-definition.ts
@@ -117,6 +117,7 @@ export default function buildDefinition(
         isDefault: region.name === 'children',
         visualRefreshTag: region.comment?.tags?.find(tag => tag.tagName === 'visualrefresh')?.text.trim(),
         deprecatedTag: region.comment?.tags?.find(tag => tag.tagName === 'deprecated')?.text.trim(),
+        i18nTag: region.comment?.tags?.find(tag => tag.tagName === 'i18n')?.text.trim(),
       };
     }),
     functions: buildMethodsDefinition(objects.find(def => def.name === 'Ref')),
@@ -131,6 +132,7 @@ export default function buildDefinition(
         defaultValue: defaultValues[prop.name],
         visualRefreshTag: prop.comment?.tags?.find(tag => tag.tagName === 'visualrefresh')?.text.trim(),
         deprecatedTag: prop.comment?.tags?.find(tag => tag.tagName === 'deprecated')?.text.trim(),
+        i18nTag: prop.comment?.tags?.find(tag => tag.tagName === 'i18n')?.text.trim(),
       };
     }),
     events: events.map(handler => buildEventInfo(handler)),

--- a/test/components/i18n-tag.test.ts
+++ b/test/components/i18n-tag.test.ts
@@ -1,0 +1,49 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { ComponentDefinition } from '../../src/components/interfaces';
+import { buildProject } from './test-helpers';
+
+let component: ComponentDefinition;
+beforeAll(() => {
+  const result = buildProject('i18n-tag');
+  expect(result).toHaveLength(1);
+
+  component = result[0];
+});
+
+test.only('should have correct region and properties definitions', () => {
+  expect(component.properties).toEqual([
+    {
+      defaultValue: undefined,
+      deprecatedTag: undefined,
+      i18nTag: undefined,
+      description: 'Adds the specified classes to the root element of the component.',
+      inlineType: undefined,
+      name: 'className',
+      optional: true,
+      type: 'string',
+      visualRefreshTag: undefined,
+    },
+    {
+      defaultValue: undefined,
+      deprecatedTag: undefined,
+      description: 'Header',
+      i18nTag: '',
+      inlineType: undefined,
+      name: 'header',
+      optional: true,
+      type: 'string',
+      visualRefreshTag: undefined,
+    },
+  ]);
+  expect(component.regions).toEqual([
+    {
+      i18nTag: 'Special instructions',
+      description: 'Main content',
+      displayName: 'content',
+      isDefault: true,
+      name: 'children',
+      visualRefreshTag: undefined,
+    },
+  ]);
+});


### PR DESCRIPTION
*Description of changes:* As part of adding internationalization to components, we want to annotate which properties no longer need to be provided. So this tag allows us to specify that in the docs.

In the string files, we want to avoid duplication, so many strings that just exist to be proxied to inner components are removed. But the information needs to exist _somewhere_ that they're optional — and the API is where it goes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
