### PR TITLE
fix npm ERESOLVE error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "lint-staged": "^13.2.1",
         "prettier": "^2.3.2",
         "ts-jest": "^27.0.1",
-        "typescript": "^4.3.2"
+        "typescript": "~4.0.8"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -6196,9 +6196,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
-      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.8.tgz",
+      "integrity": "sha512-oz1765PN+imfz1MlZzSZPtC/tqcwsCyIYA8L47EkRnRW97ztRk83SzMiWLrnChC0vqoYxSU1fcFUDA5gV/ZiPg==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11189,9 +11189,9 @@
       "integrity": "sha512-Y4Lf+qIb9NTydrexlazAM46SSLrmrQRqWiD52593g53SsmUFioAsMWt8m834J6qsp+7wHRjxCXSZeiiW5cMUdw=="
     },
     "typescript": {
-      "version": "4.9.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
-      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg=="
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.8.tgz",
+      "integrity": "sha512-oz1765PN+imfz1MlZzSZPtC/tqcwsCyIYA8L47EkRnRW97ztRk83SzMiWLrnChC0vqoYxSU1fcFUDA5gV/ZiPg=="
     },
     "uglify-js": {
       "version": "3.17.4",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "lint-staged": "^13.2.1",
     "prettier": "^2.3.2",
     "ts-jest": "^27.0.1",
-    "typescript": "^4.3.2"
+    "typescript": "~4.0.8"
   },
   "dependencies": {
     "change-case": "^4.1.1",


### PR DESCRIPTION
Fix for this `npm install` error:

```
npm ERR! code ERESOLVE
npm ERR! ERESOLVE could not resolve
npm ERR!
npm ERR! While resolving: typedoc@0.19.2
npm ERR! Found: typescript@4.9.4
npm ERR! node_modules/typescript
npm ERR!   dev typescript@"^4.3.2" from the root project
npm ERR!   peer typescript@">=3.8 <5.0" from ts-jest@27.1.5
npm ERR!   node_modules/ts-jest
npm ERR!     dev ts-jest@"^27.0.1" from the root project
npm ERR!   1 more (tsutils)
npm ERR!
npm ERR! Could not resolve dependency:
npm ERR! peer typescript@"3.9.x || 4.0.x" from typedoc@0.19.2
npm ERR! node_modules/typedoc
npm ERR!   typedoc@"~0.19.2" from the root project
npm ERR!
npm ERR! Conflicting peer dependency: typescript@4.0.8
npm ERR! node_modules/typescript
npm ERR!   peer typescript@"3.9.x || 4.0.x" from typedoc@0.19.2
npm ERR!   node_modules/typedoc
npm ERR!     typedoc@"~0.19.2" from the root project
npm ERR!
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
```

`typedoc` depends on TypeScript `4.0.x`, but version `4.3.2` is installed.

**Environment:**
Node 18.6.0
NPM 9.7.2
Windows 10 x64