### PR TITLE
support `exactOptionalPropertyTypes`

### DIFF
--- a/fixtures/components/exact-optional-property-types/button/index.tsx
+++ b/fixtures/components/exact-optional-property-types/button/index.tsx
@@ -1,0 +1,23 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import * as React from 'react';
+import { CancelableEventHandler } from '../../internal/events';
+
+export interface ButtonProps {
+  /**
+   * String example
+   */
+  children: string;
+
+  /**
+   * Fired when user clicks
+   */
+  onClick?: CancelableEventHandler | undefined;
+}
+
+/**
+ * Component-level description
+ */
+export default function Button({ children, onClick }: ButtonProps) {
+  return <button onClick={onClick}>{children}</button>;
+}

--- a/fixtures/components/exact-optional-property-types/tsconfig.json
+++ b/fixtures/components/exact-optional-property-types/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig.json",
+  "include": ["./**/*.tsx"]
+}

--- a/test/components/exact-optional-properties-types.test.ts
+++ b/test/components/exact-optional-properties-types.test.ts
@@ -1,0 +1,35 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { ComponentDefinition } from '../../src/components/interfaces';
+import { buildProject } from './test-helpers';
+
+let component: ComponentDefinition;
+beforeAll(() => {
+  const result = buildProject('exact-optional-property-types');
+  expect(result).toHaveLength(1);
+
+  component = result[0];
+});
+
+test('should have correct properties', () => {
+  expect(component.properties).toEqual([
+    {
+      name: 'children',
+      description: 'String example',
+      type: 'string',
+      optional: false,
+      defaultValue: undefined,
+    },
+  ]);
+});
+
+test('should have correct events', () => {
+  expect(component.events).toEqual([
+    {
+      name: 'onClick',
+      description: 'Fired when user clicks',
+      cancelable: true,
+      detailType: undefined,
+    },
+  ]);
+});


### PR DESCRIPTION
I don't know how you handle version bumping, so I didn't try. Theoretically, this should be `1.0.10`.

*Issue #, if available:* resolves #23

*Description of changes:*

Regarding [cloudscape-design/components#1108](https://github.com/cloudscape-design/components/pull/1108),

>the build failed at the documentation step. Fixing the Documenter is a big deal and our team can't afford it at the moment.

Here's the fix.

#### Details

`buildEventInfo` requires two pieces of information:
1. metadata on the handler
2. metadata on the reference type

When building event info for union types, it finds the reference type in the union, then grabs the respective metadata: from the handler and from the reference type in the union
For non-union reference types, the same logic still occurs: it grabs the metadata from the handler and from the reference type.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
