### PR TITLE
chore: Switch to new actions repo for workflows

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -15,5 +15,5 @@ permissions:
 
 jobs:
   build:
-    uses: cloudscape-design/.github/.github/workflows/build-lint-test.yml@main
+    uses: cloudscape-design/actions/.github/workflows/build-lint-test.yml@main
     secrets: inherit

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -9,4 +9,4 @@ on:
 
 jobs:
   dry-run:
-    uses: cloudscape-design/.github/.github/workflows/dry-run.yml@main
+    uses: cloudscape-design/actions/.github/workflows/dry-run.yml@main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,5 +14,5 @@ permissions:
 
 jobs:
   release:
-    uses: cloudscape-design/.github/.github/workflows/release.yml@main
+    uses: cloudscape-design/actions/.github/workflows/release.yml@main
     secrets: inherit


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR switches to the new shared repository for GitHub workflows and actions: https://github.com/cloudscape-design/actions.

For the most recent changes to the shared workflows, see https://github.com/cloudscape-design/actions/pull/1. The new configuration was successfully tested in this Draft PR: https://github.com/cloudscape-design/components/pull/1672.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
