### PR TITLE
chore: Update returnsReactContent to handle varied JSX.Element or ReactPortal paths

### DIFF
--- a/src/components/components-extractor.ts
+++ b/src/components/components-extractor.ts
@@ -12,8 +12,8 @@ function returnsReactContent(node: DeclarationReflection) {
   return node.signatures?.some(
     ({ type }) =>
       schema.types.isReferenceType(type) &&
-      (type.symbolFullyQualifiedName.includes('JSX.Element') ||
-        type.symbolFullyQualifiedName.includes('React.ReactPortal'))
+      (type.symbolFullyQualifiedName.endsWith('JSX.Element') ||
+        type.symbolFullyQualifiedName.endsWith('React.ReactPortal'))
   );
 }
 

--- a/src/components/components-extractor.ts
+++ b/src/components/components-extractor.ts
@@ -12,7 +12,8 @@ function returnsReactContent(node: DeclarationReflection) {
   return node.signatures?.some(
     ({ type }) =>
       schema.types.isReferenceType(type) &&
-      (type.symbolFullyQualifiedName === 'global.JSX.Element' || type.symbolFullyQualifiedName === 'React.ReactPortal')
+      (type.symbolFullyQualifiedName.includes('JSX.Element') ||
+        type.symbolFullyQualifiedName.includes('React.ReactPortal'))
   );
 }
 

--- a/src/schema/utils.ts
+++ b/src/schema/utils.ts
@@ -18,9 +18,7 @@ export function isForwardRefDeclaration({ type, name }: DeclarationReflection): 
     isReferenceType(type) &&
       type.name === `${name}ForwardRefType` &&
       (type.reflection as DeclarationReflection | undefined)?.signatures?.some(({ name, type }) => {
-        return (
-          name === '__call' && isReferenceType(type) && type.symbolFullyQualifiedName.endsWith('global.JSX.Element')
-        );
+        return name === '__call' && isReferenceType(type) && type.symbolFullyQualifiedName.endsWith('JSX.Element');
       })
   );
   return isForwardRef || isParametrizedForwardRef;

--- a/src/schema/utils.ts
+++ b/src/schema/utils.ts
@@ -12,12 +12,15 @@ export function isOptionalDeclaration(prop: DeclarationReflection): boolean {
 }
 
 export function isForwardRefDeclaration({ type, name }: DeclarationReflection): boolean {
-  const isForwardRef = isReferenceType(type) && type.symbolFullyQualifiedName === 'React.ForwardRefExoticComponent';
+  const isForwardRef =
+    isReferenceType(type) && type.symbolFullyQualifiedName.endsWith('React.ForwardRefExoticComponent');
   const isParametrizedForwardRef = Boolean(
     isReferenceType(type) &&
       type.name === `${name}ForwardRefType` &&
       (type.reflection as DeclarationReflection | undefined)?.signatures?.some(({ name, type }) => {
-        return name === '__call' && isReferenceType(type) && type.symbolFullyQualifiedName === 'global.JSX.Element';
+        return (
+          name === '__call' && isReferenceType(type) && type.symbolFullyQualifiedName.endsWith('global.JSX.Element')
+        );
       })
   );
   return isForwardRef || isParametrizedForwardRef;


### PR DESCRIPTION
*Description of changes:*
Modified the `returnsReactContent` function to check for `'JSX.Element'` and `'React.ReactPortal'` in `type.symbolFullyQualifiedName` using string `endsWith`. 
This change works with different TypeScript module resolution strategies where the fully qualified name might resolve to a module-specific path, e.g., `'"node_modules/@types/react/ts5.0/jsx-runtime".JSX.Element'`, instead of only matching exact paths like `'global.JSX.Element'` or `'React.ReactPortal'`.
 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
