### PR TITLE
chore: Use explicit typescript override

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "prettier": "^2.3.2",
         "rimraf": "^5.0.5",
         "ts-jest": "^27.0.1",
-        "typescript": "^4.3.2"
+        "typescript": "^4.9.4"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -34,13 +34,16 @@
     "prettier": "^2.3.2",
     "rimraf": "^5.0.5",
     "ts-jest": "^27.0.1",
-    "typescript": "^4.3.2"
+    "typescript": "^4.9.4"
   },
   "dependencies": {
     "change-case": "^4.1.1",
     "micromatch": "^4.0.2",
     "pathe": "^1.1.2",
     "typedoc": "~0.19.2"
+  },
+  "overrides": {
+    "typescript": "^4.9.4"
   },
   "lint-staged": {
     "*.{ts,tsx,js}": [


### PR DESCRIPTION
*Issue #, if available:*

Allow this package to run `npm install` without the `--force` flag. 

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
