### PR TITLE
chore: Add support for analytics tag

### DIFF
--- a/fixtures/components/analytics-tag/example/index.tsx
+++ b/fixtures/components/analytics-tag/example/index.tsx
@@ -1,0 +1,15 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import * as React from 'react';
+
+export interface ExampleProps {
+  /**
+   * @analytics View details in Analytics tab
+   */
+  analyticsMetadata?: string;
+  children?: React.ReactNode;
+}
+
+export default function Example({ children }: ExampleProps): JSX.Element {
+  return <div>{children}</div>;
+}

--- a/fixtures/components/analytics-tag/tsconfig.json
+++ b/fixtures/components/analytics-tag/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["./**/*.tsx"]
+}

--- a/src/components/build-definition.ts
+++ b/src/components/build-definition.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { DeclarationReflection, ReflectionKind } from 'typedoc';
 import { Type } from 'typedoc/dist/lib/models';
-import { ComponentDefinition, ComponentFunction } from './interfaces';
+import { ComponentDefinition, ComponentFunction, ComponentProperty } from './interfaces';
 import schema from '../schema';
 import buildTypeDefinition from './build-type-definition';
 import extractDefaultValues from './default-values-extractor';
@@ -133,6 +133,7 @@ export default function buildDefinition(
         visualRefreshTag: prop.comment?.tags?.find(tag => tag.tagName === 'visualrefresh')?.text.trim(),
         deprecatedTag: prop.comment?.tags?.find(tag => tag.tagName === 'deprecated')?.text.trim(),
         i18nTag: prop.comment?.tags?.some(tag => tag.tagName === 'i18n') || undefined,
+        analyticsTag: prop.comment?.tags?.find(tag => tag.tagName === 'analytics')?.text.trim(),
       };
     }),
     events: events.map(handler => buildEventInfo(handler)),

--- a/src/components/interfaces.ts
+++ b/src/components/interfaces.ts
@@ -18,6 +18,7 @@ export interface ComponentProperty {
   type: string;
   inlineType?: TypeDefinition;
   defaultValue?: string;
+  analyticsTag?: string;
 }
 
 export interface ComponentRegion {

--- a/test/components/analytics-tag.test.ts
+++ b/test/components/analytics-tag.test.ts
@@ -1,0 +1,46 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { ComponentDefinition } from '../../src/components/interfaces';
+import { buildProject } from './test-helpers';
+
+describe('Analytics tag', () => {
+  let component: ComponentDefinition;
+  beforeAll(() => {
+    const result = buildProject('analytics-tag');
+    expect(result).toHaveLength(1);
+
+    component = result[0];
+  });
+
+  test('should have correct properties definitions', () => {
+    expect(component.properties).toEqual([
+      {
+        name: 'analyticsMetadata',
+        analyticsTag: 'View details in Analytics tab',
+        defaultValue: undefined,
+        deprecatedTag: undefined,
+        description: '',
+        i18nTag: undefined,
+        inlineType: undefined,
+        optional: true,
+        type: 'string',
+        visualRefreshTag: undefined,
+      },
+    ]);
+  });
+
+  test('should have correct regions definitions', () => {
+    expect(component.regions).toEqual([
+      {
+        name: 'children',
+        analyticsTag: undefined,
+        isDefault: true,
+        deprecatedTag: undefined,
+        description: undefined,
+        displayName: undefined,
+        i18nTag: undefined,
+        visualRefreshTag: undefined,
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
*Description of changes:*
As part of adding in the analyticsMetadata property in the components, we will be tagging the property document with an `analytics` tag to allow for better documentation on the website.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
