### PR TITLE
chore: Support third party type imports

### DIFF
--- a/fixtures/components/third-party-import-types/button/index.tsx
+++ b/fixtures/components/third-party-import-types/button/index.tsx
@@ -1,0 +1,14 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import * as React from 'react';
+
+import { ButtonProps } from './interfaces';
+
+export { ButtonProps };
+
+/**
+ * Component-level description
+ */
+export default function Button({ iconName }: ButtonProps) {
+  return <div className={iconName}>{iconName}</div>;
+}

--- a/fixtures/components/third-party-import-types/button/interfaces.ts
+++ b/fixtures/components/third-party-import-types/button/interfaces.ts
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { IconProps } from '../node_modules/icon';
+import { IconProps } from '../node_modules_mock/icon';
 
 export interface ButtonProps {
   /**

--- a/fixtures/components/third-party-import-types/button/interfaces.ts
+++ b/fixtures/components/third-party-import-types/button/interfaces.ts
@@ -1,0 +1,10 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { IconProps } from '../node_modules/icon';
+
+export interface ButtonProps {
+  /**
+   * This is icon name
+   */
+  iconName: IconProps.Name;
+}

--- a/fixtures/components/third-party-import-types/node_modules_mock/icon/index.d.ts
+++ b/fixtures/components/third-party-import-types/node_modules_mock/icon/index.d.ts
@@ -1,0 +1,4 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { IconProps } from './interfaces';
+export { IconProps };

--- a/fixtures/components/third-party-import-types/node_modules_mock/icon/interfaces.d.ts
+++ b/fixtures/components/third-party-import-types/node_modules_mock/icon/interfaces.d.ts
@@ -1,0 +1,11 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+export interface IconProps {
+  /**
+   * Specifies the icon to be displayed.
+   */
+  name?: IconProps.Name;
+}
+export declare namespace IconProps {
+  type Name = 'icon1' | 'icon2' | 'icon3';
+}

--- a/fixtures/components/third-party-import-types/tsconfig.json
+++ b/fixtures/components/third-party-import-types/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "button"
+  },
+  "include": ["button"]
+}

--- a/src/bootstrap/index.ts
+++ b/src/bootstrap/index.ts
@@ -8,7 +8,7 @@ import { resolve } from 'pathe';
 export function bootstrapProject(
   options: Partial<TypeDocAndTSOptions>,
   filteringGlob?: string,
-  nodeModulesInputFilePaths?: string[]
+  additionalInputFilePaths?: string[]
 ): ProjectReflection {
   const app = new Application();
   app.options.addReader(new TSConfigReader());
@@ -18,8 +18,8 @@ export function bootstrapProject(
     throw new Error('Errors during parsing configuration');
   }
 
-  if (nodeModulesInputFilePaths?.length) {
-    inputFiles.push(...nodeModulesInputFilePaths);
+  if (additionalInputFilePaths?.length) {
+    inputFiles.push(...additionalInputFilePaths);
   }
 
   const filteredInputFiles = filterFiles(inputFiles, filteringGlob);

--- a/src/bootstrap/index.ts
+++ b/src/bootstrap/index.ts
@@ -5,13 +5,21 @@ import { TypeDocAndTSOptions, Application, TSConfigReader, ProjectReflection } f
 import { matcher } from 'micromatch';
 import { resolve } from 'pathe';
 
-export function bootstrapProject(options: Partial<TypeDocAndTSOptions>, filteringGlob?: string): ProjectReflection {
+export function bootstrapProject(
+  options: Partial<TypeDocAndTSOptions>,
+  filteringGlob?: string,
+  nodeModulesInputFilePaths?: string[]
+): ProjectReflection {
   const app = new Application();
   app.options.addReader(new TSConfigReader());
 
   const { inputFiles, hasErrors } = app.bootstrap(options);
   if (hasErrors) {
     throw new Error('Errors during parsing configuration');
+  }
+
+  if (nodeModulesInputFilePaths?.length) {
+    inputFiles.push(...nodeModulesInputFilePaths);
   }
 
   const filteredInputFiles = filterFiles(inputFiles, filteringGlob);

--- a/src/components/components-extractor.ts
+++ b/src/components/components-extractor.ts
@@ -86,7 +86,11 @@ function findProps(allDefinitions: DeclarationReflection[], propsName: string, d
   };
 }
 
-export default function extractComponents(publicFilesGlob: string, project: ProjectReflection): ComponentDefinition[] {
+export default function extractComponents(
+  publicFilesGlob: string,
+  project: ProjectReflection,
+  hasCoreComponentTypeDependency?: boolean
+): ComponentDefinition[] {
   const definitions: ComponentDefinition[] = [];
   const isMatch = matcher(resolve(publicFilesGlob));
 
@@ -96,6 +100,10 @@ export default function extractComponents(publicFilesGlob: string, project: Proj
 
   const allDefinitions = project.children.flatMap(module => {
     if (!module.children) {
+      if (hasCoreComponentTypeDependency) {
+        return [];
+      }
+
       throw new Error(`Module ${module.originalName} does not contain a definition.`);
     }
 

--- a/src/components/components-extractor.ts
+++ b/src/components/components-extractor.ts
@@ -86,11 +86,7 @@ function findProps(allDefinitions: DeclarationReflection[], propsName: string, d
   };
 }
 
-export default function extractComponents(
-  publicFilesGlob: string,
-  project: ProjectReflection,
-  hasCoreComponentTypeDependency?: boolean
-): ComponentDefinition[] {
+export default function extractComponents(publicFilesGlob: string, project: ProjectReflection): ComponentDefinition[] {
   const definitions: ComponentDefinition[] = [];
   const isMatch = matcher(resolve(publicFilesGlob));
 
@@ -100,10 +96,6 @@ export default function extractComponents(
 
   const allDefinitions = project.children.flatMap(module => {
     if (!module.children) {
-      if (hasCoreComponentTypeDependency) {
-        return [];
-      }
-
       throw new Error(`Module ${module.originalName} does not contain a definition.`);
     }
 

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -5,12 +5,18 @@ import { ComponentDefinition } from './interfaces';
 import extractComponents from './components-extractor';
 import { bootstrapProject } from '../bootstrap';
 
+/**
+ * @param tsconfigPath Path to tsconfig file
+ * @param publicFilesGlob Filter to obtain public files
+ * @param nodeModulesDependencyFilePaths node_modules paths of libraries to include in documentation e.g.["dir/node_modules/@cloudscape-design/components/icon/interfaces.d.ts"]
+ * @returns Component definitions
+ */
 export function documentComponents(
   tsconfigPath: string,
   publicFilesGlob: string,
-  nodeModulesInputFilePaths?: string[]
+  nodeModulesDependencyFilePaths?: string[]
 ): ComponentDefinition[] {
-  const includeNodeModulePaths = Boolean(nodeModulesInputFilePaths?.length);
+  const includeNodeModulePaths = Boolean(nodeModulesDependencyFilePaths?.length);
   const project = bootstrapProject(
     {
       tsconfig: tsconfigPath,
@@ -18,7 +24,7 @@ export function documentComponents(
       excludeExternals: includeNodeModulePaths,
     },
     undefined,
-    nodeModulesInputFilePaths
+    nodeModulesDependencyFilePaths
   );
   return extractComponents(publicFilesGlob, project);
 }

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -8,11 +8,17 @@ import { bootstrapProject } from '../bootstrap';
 export function documentComponents(
   tsconfigPath: string,
   publicFilesGlob: string,
-  hasCoreComponentTypeDependency?: boolean
+  nodeModulesInputFilePaths?: string[]
 ): ComponentDefinition[] {
-  const project = bootstrapProject({
-    tsconfig: tsconfigPath,
-    includeDeclarations: hasCoreComponentTypeDependency,
-  });
-  return extractComponents(publicFilesGlob, project, hasCoreComponentTypeDependency);
+  const includeNodeModulePaths = Boolean(nodeModulesInputFilePaths?.length);
+  const project = bootstrapProject(
+    {
+      tsconfig: tsconfigPath,
+      includeDeclarations: includeNodeModulePaths,
+      excludeExternals: includeNodeModulePaths,
+    },
+    undefined,
+    nodeModulesInputFilePaths
+  );
+  return extractComponents(publicFilesGlob, project);
 }

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -5,7 +5,14 @@ import { ComponentDefinition } from './interfaces';
 import extractComponents from './components-extractor';
 import { bootstrapProject } from '../bootstrap';
 
-export function documentComponents(tsconfigPath: string, publicFilesGlob: string): ComponentDefinition[] {
-  const project = bootstrapProject({ tsconfig: tsconfigPath });
-  return extractComponents(publicFilesGlob, project);
+export function documentComponents(
+  tsconfigPath: string,
+  publicFilesGlob: string,
+  hasCoreComponentTypeDependency?: boolean
+): ComponentDefinition[] {
+  const project = bootstrapProject({
+    tsconfig: tsconfigPath,
+    includeDeclarations: hasCoreComponentTypeDependency,
+  });
+  return extractComponents(publicFilesGlob, project, hasCoreComponentTypeDependency);
 }

--- a/test/components/test-helpers.ts
+++ b/test/components/test-helpers.ts
@@ -7,10 +7,11 @@ import { TestUtilsDoc } from '../../src/test-utils/interfaces';
 
 // TODO: Move this file into common location, improve naming
 
-export function buildProject(name: string): ComponentDefinition[] {
+export function buildProject(name: string, nodeModulesInputFilePaths?: string[]): ComponentDefinition[] {
   return documentComponents(
     require.resolve(`../../fixtures/components/${name}/tsconfig.json`),
-    `fixtures/components/${name}/*/index.tsx`
+    `fixtures/components/${name}/*/index.tsx`,
+    nodeModulesInputFilePaths
   );
 }
 

--- a/test/components/test-helpers.ts
+++ b/test/components/test-helpers.ts
@@ -7,11 +7,11 @@ import { TestUtilsDoc } from '../../src/test-utils/interfaces';
 
 // TODO: Move this file into common location, improve naming
 
-export function buildProject(name: string, nodeModulesInputFilePaths?: string[]): ComponentDefinition[] {
+export function buildProject(name: string, nodeModulesDependencyFilePaths?: string[]): ComponentDefinition[] {
   return documentComponents(
     require.resolve(`../../fixtures/components/${name}/tsconfig.json`),
     `fixtures/components/${name}/*/index.tsx`,
-    nodeModulesInputFilePaths
+    nodeModulesDependencyFilePaths
   );
 }
 

--- a/test/components/third-party-import-types.test.ts
+++ b/test/components/third-party-import-types.test.ts
@@ -2,8 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 import { buildProject } from './test-helpers';
 import { ComponentDefinition } from '../../src';
+import * as bootstrap from '../../src/bootstrap';
 import process from 'node:process';
 const cwd = process.cwd();
+const nodeModulesPath = `${cwd}/fixtures/components/third-party-import-types/node_modules_mock/icon/interfaces.d.ts`;
 
 test('should resolve object type to string', () => {
   const resultBefore = buildProject('third-party-import-types');
@@ -24,9 +26,7 @@ test('should resolve object type to string', () => {
     },
   ]);
 
-  const resultAfter = buildProject('third-party-import-types', [
-    `${cwd}/fixtures/components/third-party-import-types/node_modules_mock/icon/interfaces.d.ts`,
-  ]);
+  const resultAfter = buildProject('third-party-import-types', [nodeModulesPath]);
   const buttonAfter: ComponentDefinition | undefined = resultAfter.find(component => component.name === 'Button');
 
   expect(buttonAfter?.properties).toEqual([
@@ -43,4 +43,14 @@ test('should resolve object type to string', () => {
       analyticsTag: undefined,
     },
   ]);
+});
+
+test('passing nodeModulesInputFilePaths should enable includeDeclarations and excludeExternals', () => {
+  const bootstrapProjectSpy = jest.spyOn(bootstrap, 'bootstrapProject');
+  buildProject('third-party-import-types', [nodeModulesPath]);
+
+  expect(bootstrapProjectSpy.mock.calls[0][0].includeDeclarations).toBe(true);
+  expect(bootstrapProjectSpy.mock.calls[0][0].excludeExternals).toBe(true);
+
+  jest.restoreAllMocks();
 });

--- a/test/components/third-party-import-types.test.ts
+++ b/test/components/third-party-import-types.test.ts
@@ -25,7 +25,7 @@ test('should resolve object type to string', () => {
   ]);
 
   const resultAfter = buildProject('third-party-import-types', [
-    `${cwd}/fixtures/components/third-party-import-types/node_modules/icon/interfaces.d.ts`,
+    `${cwd}/fixtures/components/third-party-import-types/node_modules_mock/icon/interfaces.d.ts`,
   ]);
   const buttonAfter: ComponentDefinition | undefined = resultAfter.find(component => component.name === 'Button');
 

--- a/test/components/third-party-import-types.test.ts
+++ b/test/components/third-party-import-types.test.ts
@@ -45,7 +45,7 @@ test('should resolve object type to string', () => {
   ]);
 });
 
-test('passing nodeModulesInputFilePaths should enable includeDeclarations and excludeExternals', () => {
+test('passing nodeModulesDependencyFilePaths should enable includeDeclarations and excludeExternals', () => {
   const bootstrapProjectSpy = jest.spyOn(bootstrap, 'bootstrapProject');
   buildProject('third-party-import-types', [nodeModulesPath]);
 

--- a/test/components/third-party-import-types.test.ts
+++ b/test/components/third-party-import-types.test.ts
@@ -1,0 +1,46 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { buildProject } from './test-helpers';
+import { ComponentDefinition } from '../../src';
+import process from 'node:process';
+const cwd = process.cwd();
+
+test('should resolve object type to string', () => {
+  const resultBefore = buildProject('third-party-import-types');
+  const buttonBefore: ComponentDefinition | undefined = resultBefore.find(component => component.name === 'Button');
+
+  expect(buttonBefore?.properties).toEqual([
+    {
+      name: 'iconName',
+      type: 'IconProps.Name',
+      inlineType: undefined,
+      optional: false,
+      description: 'This is icon name',
+      defaultValue: undefined,
+      visualRefreshTag: undefined,
+      deprecatedTag: undefined,
+      i18nTag: undefined,
+      analyticsTag: undefined,
+    },
+  ]);
+
+  const resultAfter = buildProject('third-party-import-types', [
+    `${cwd}/fixtures/components/third-party-import-types/node_modules/icon/interfaces.d.ts`,
+  ]);
+  const buttonAfter: ComponentDefinition | undefined = resultAfter.find(component => component.name === 'Button');
+
+  expect(buttonAfter?.properties).toEqual([
+    {
+      name: 'iconName',
+      type: 'string',
+      inlineType: { name: 'IconProps.Name', type: 'union', values: ['icon1', 'icon2', 'icon3'] },
+      optional: false,
+      description: 'This is icon name',
+      defaultValue: undefined,
+      visualRefreshTag: undefined,
+      deprecatedTag: undefined,
+      i18nTag: undefined,
+      analyticsTag: undefined,
+    },
+  ]);
+});


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* This PR adds nodeModulesInputFilePaths to accept additional file paths to be added to inputFiles option of typedoc. When it is defined, it enables includeDeclarations and excludeExternals as well. More details can be found in Uzu5AkM2GZiY. Related chat components PR: https://github.com/cloudscape-design/chat-components/pull/18

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
