### PR TITLE
chore: Trigger required workflows on merge_group event

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - main
+  merge_group:
 
 permissions:
   actions: read

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     branches:
       - main
+  merge_group:
 
 jobs:
   dry-run:


### PR DESCRIPTION
*Description of changes:*

to enable merge queue feature in the repo, trigger workflows that are checked in PR when merge queue is requested.

https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions

tested in global-styles repo: https://github.com/cloudscape-design/global-styles/pull/48

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
