### PR TITLE
chore: fix documentComponents functions signature

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -16,20 +16,41 @@ function componentNameFromPath(componentPath: string) {
 }
 
 export interface DocumenterOptions {
+  tsconfigPath: string;
+  publicFilesGlob: string;
   extraExports?: Record<string, Array<string>>;
 }
-
 export function documentComponents(
   tsconfigPath: string,
   publicFilesGlob: string,
   // deprecated, now unused
   additionalInputFilePaths?: Array<string>,
   options?: DocumenterOptions
+): Array<ComponentDefinition>;
+export function documentComponents(options: DocumenterOptions): Array<ComponentDefinition>;
+export function documentComponents(
+  ...args:
+    | [
+        tsconfigPath: string,
+        publicFilesGlob: string,
+        additionalInputFilePaths?: Array<string>,
+        options?: DocumenterOptions
+      ]
+    | [options: DocumenterOptions]
 ): Array<ComponentDefinition> {
-  const program = bootstrapTypescriptProject(tsconfigPath);
+  const options =
+    args.length === 1
+      ? args[0]
+      : {
+          tsconfigPath: args[0],
+          publicFilesGlob: args[1],
+          additionalInputFilePaths: args[2],
+          ...args[3],
+        };
+  const program = bootstrapTypescriptProject(options.tsconfigPath);
   const checker = program.getTypeChecker();
 
-  const isMatch = matcher(pathe.resolve(publicFilesGlob));
+  const isMatch = matcher(pathe.resolve(options.publicFilesGlob));
 
   return program
     .getSourceFiles()

--- a/test/components/legacy.test.ts
+++ b/test/components/legacy.test.ts
@@ -1,0 +1,11 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { documentComponents } from '../../src';
+
+test('legacy API works', () => {
+  const definitions = documentComponents(
+    require.resolve(`../../fixtures/components/simple/tsconfig.json`),
+    `fixtures/components/simple/*/index.tsx`
+  );
+  expect(definitions).toHaveLength(1);
+});

--- a/test/components/test-helpers.ts
+++ b/test/components/test-helpers.ts
@@ -2,18 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0
 import ts from 'typescript';
 import { ProjectReflection } from 'typedoc';
-import { ComponentDefinition, documentComponents, documentTestUtils } from '../../src';
+import { documentComponents, documentTestUtils } from '../../src';
 import { bootstrapProject } from '../../src/bootstrap';
 import { TestUtilsDoc } from '../../src/test-utils/interfaces';
 import { DocumenterOptions } from '../../src/components';
 
-export function buildProject(name: string, options?: DocumenterOptions): ComponentDefinition[] {
-  return documentComponents(
-    require.resolve(`../../fixtures/components/${name}/tsconfig.json`),
-    `fixtures/components/${name}/*/index.tsx`,
-    undefined,
-    options
-  );
+export function buildProject(name: string, options?: Partial<DocumenterOptions>) {
+  return documentComponents({
+    tsconfigPath: require.resolve(`../../fixtures/components/${name}/tsconfig.json`),
+    publicFilesGlob: `fixtures/components/${name}/*/index.tsx`,
+    ...options,
+  });
 }
 
 export function buildTestUtilsProject(name: string, testGlob?: string): TestUtilsDoc[] {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

It is now 4 arguments, with holes in between, `documentComponents(tsconfig, glob, undefined, options)`. Time to switch from multi-arguments to a single `options` argument


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
