### PR TITLE
feat: Add helper to write documentation files

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
     "*.js",
     "*.d.ts"
   ],
+  "exports": {
+    ".": "./index.js"
+  },
   "scripts": {
     "lint": "eslint --ignore-path .gitignore --ext js,ts,tsx .",
     "prebuild": "rimraf lib",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 export * from './components/interfaces';
-export { documentComponents } from './components';
+export { documentComponents, writeComponentsDocumentation } from './components';
 export { documentTestUtils } from './test-utils';

--- a/test/components/errors.test.ts
+++ b/test/components/errors.test.ts
@@ -7,6 +7,16 @@ test('should throw in case of configuration errors', () => {
   expect(() => buildProject('errors-config')).toThrow('Failed to parse tsconfig.json');
 });
 
+test('should throw if tsconfig is not found', () => {
+  expect(() => buildProject('fixture-does-not-exist')).toThrow('Failed to read tsconfig.json');
+});
+
+test('should throw if no components in the output', () => {
+  expect(() => buildProject('simple', { publicFilesGlob: 'does-not-exist' })).toThrow(
+    'No files found matching does-not-exist'
+  );
+});
+
 test('should throw in case of type errors', () => {
   expect(() => buildProject('errors-types')).toThrow('Compilation failed');
 });

--- a/test/components/test-helpers.ts
+++ b/test/components/test-helpers.ts
@@ -1,5 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import fs from 'node:fs';
+import os from 'node:os';
+import pathe from 'pathe';
 import ts from 'typescript';
 import { ProjectReflection } from 'typedoc';
 import { documentComponents, documentTestUtils } from '../../src';
@@ -13,6 +16,10 @@ export function buildProject(name: string, options?: Partial<DocumenterOptions>)
     publicFilesGlob: `fixtures/components/${name}/*/index.tsx`,
     ...options,
   });
+}
+
+export function getTemporaryDir() {
+  return fs.mkdtempSync(pathe.join(os.tmpdir(), 'documenter-'));
 }
 
 export function buildTestUtilsProject(name: string, testGlob?: string): TestUtilsDoc[] {

--- a/test/components/test-helpers.ts
+++ b/test/components/test-helpers.ts
@@ -12,7 +12,7 @@ import { DocumenterOptions } from '../../src/components';
 
 export function buildProject(name: string, options?: Partial<DocumenterOptions>) {
   return documentComponents({
-    tsconfigPath: require.resolve(`../../fixtures/components/${name}/tsconfig.json`),
+    tsconfigPath: pathe.resolve(`fixtures/components/${name}/tsconfig.json`),
     publicFilesGlob: `fixtures/components/${name}/*/index.tsx`,
     ...options,
   });

--- a/test/components/writer.test.ts
+++ b/test/components/writer.test.ts
@@ -1,0 +1,25 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { expect, test } from 'vitest';
+import fs from 'node:fs';
+import pathe from 'pathe';
+import { getTemporaryDir } from './test-helpers';
+// must use compiled artifacts, because the code relies on generated files
+import { writeComponentsDocumentation } from '../../lib';
+
+test('should write documentation files into the outDir', async () => {
+  const outDir = getTemporaryDir();
+  expect(fs.readdirSync(outDir)).toHaveLength(0);
+
+  writeComponentsDocumentation({
+    tsconfigPath: pathe.resolve('fixtures/components/simple/tsconfig.json'),
+    publicFilesGlob: 'fixtures/components/simple/*/index.tsx',
+    outDir,
+  });
+
+  expect(fs.readdirSync(outDir)).toEqual(['index.d.ts', 'index.js', 'interfaces.d.ts', 'simple.js']);
+  const { default: definitions } = await import(pathe.join(outDir, 'index.js'));
+  expect(definitions).toEqual({
+    simple: expect.objectContaining({ name: 'Simple', dashCaseName: 'simple' }),
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,9 @@
     "strict": true,
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "sourceMap": true,
+    "inlineSources": true
   },
   "include": ["src"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     coverage: {
       enabled: process.env.CI === 'true',
       provider: 'v8',
-      include: ['src/**'],
+      include: ['src/**', 'lib/**'],
     },
   },
 });


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Add `writeComponentsDocumentation` function which not only generate documentation objects, but actually writes them to disk. Also see the respective components change: https://github.com/cloudscape-design/components/pull/3448


This will reduce duplications like this
* https://github.com/cloudscape-design/components/blob/053e0325143b228c206c7bb3d82c7b4b0e7d0909/build-tools/tasks/docs.js#L34-L44
* https://github.com/cloudscape-design/chat-components/blob/main/scripts/docs.js#L28-L38
* https://github.com/cloudscape-design/board-components/blob/69b272ab1137af6c53d4a7adc325066a428fa952/scripts/docs.js#L28-L38


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
