### PR TITLE
fix: Skip non-system comments when extracting descriptions

### DIFF
--- a/src/components/type-utils.ts
+++ b/src/components/type-utils.ts
@@ -86,7 +86,9 @@ export function extractValueDescriptions(type: ts.UnionOrIntersectionType, typeN
       memberIndex++;
     }
   }
-  return rawComments.map((comment): ValueDescription | undefined => {
+  // Array.from to fix sparse array
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array#array_methods_and_empty_slots
+  return Array.from(rawComments).map((comment): ValueDescription | undefined => {
     if (!comment) {
       return undefined;
     }

--- a/src/components/type-utils.ts
+++ b/src/components/type-utils.ts
@@ -86,13 +86,13 @@ export function extractValueDescriptions(type: ts.UnionOrIntersectionType, typeN
       memberIndex++;
     }
   }
-  return rawComments.map((comment): ValueDescription | undefined =>
-    comment
-      ? {
-          systemTags: Array.from(comment.matchAll(/@awsuiSystem\s+(\w+)/g), ([_, system]) => system),
-        }
-      : undefined
-  );
+  return rawComments.map((comment): ValueDescription | undefined => {
+    if (!comment) {
+      return undefined;
+    }
+    const systemTags = Array.from(comment.matchAll(/@awsuiSystem\s+(\w+)/g), ([_, system]) => system);
+    return systemTags.length > 0 ? { systemTags } : undefined;
+  });
 }
 
 export function extractDeclaration(symbol: ts.Symbol) {

--- a/test/components/value-descriptions-extractor.test.ts
+++ b/test/components/value-descriptions-extractor.test.ts
@@ -36,6 +36,16 @@ test('extract description comments', () => {
   expect(extractFromSource(source)).toEqual([{ systemTags: ['fooSystem'] }, { systemTags: ['barSystem'] }]);
 });
 
+test('should ignore non-system comments', () => {
+  const source = `export type MyUnion =
+  /** this is a foo property */
+  | 'foo'
+  /** @awsuiSystem barSystem */
+  | 'bar';`;
+
+  expect(extractFromSource(source)).toEqual([undefined, { systemTags: ['barSystem'] }]);
+});
+
 test('extract description comments from a type alias', () => {
   const source = `
   export type MyUnion = InternalUnion;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fixing a bug where an irrelevant comment may cause an unexpected systemTag value to be produced


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
