### PR TITLE
feat: Export namespace type declarations

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -73,14 +73,12 @@ export function documentComponents(options: DocumenterOptions): Array<ComponentD
     }
     const exportSymbols = checker.getExportsOfModule(moduleSymbol);
     const { propsSymbol, componentSymbol } = extractExports(name, exportSymbols, checker, options?.extraExports ?? {});
-    const props = extractProps(propsSymbol, checker);
-    const functions = extractFunctions(propsSymbol, checker);
     const defaultValues = extractDefaultValues(componentSymbol, checker);
     const componentDescription = getDescription(
       componentSymbol.getDocumentationComment(checker),
       extractDeclaration(componentSymbol)
     );
 
-    return buildComponentDefinition(name, dashCaseName, props, functions, defaultValues, componentDescription, checker);
+    return buildComponentDefinition(name, dashCaseName, propsSymbol, defaultValues, componentDescription, checker);
   });
 }

--- a/src/components/interfaces.ts
+++ b/src/components/interfaces.ts
@@ -14,6 +14,7 @@ export interface ComponentDefinition {
   regions: ComponentRegion[];
   functions: ComponentFunction[];
   events: EventHandler[];
+  types: Record<string, Record<string, never>>;
 }
 
 interface Taggable {

--- a/test/components/complex-types.test.ts
+++ b/test/components/complex-types.test.ts
@@ -193,3 +193,19 @@ test('should parse string literal type as single-value union', () => {
     },
   ]);
 });
+
+test('should export type declarations', () => {
+  expect(buttonGroup.types).toEqual({ Variant: {}, Item: {} });
+  expect(columnLayout.types).toEqual({ Columns: {}, Widths: {} });
+  expect(sideNavigation.types).toEqual({ FollowDetail: {} });
+  expect(table.types).toEqual({
+    AriaLabels: {},
+    ColumnWidthsChangeDetail: {},
+    ComplexAlias: {},
+    FilteringFunction: {},
+    Item: {},
+    SelectionState: {},
+    TableColumn: {},
+    TrackBy: {},
+  });
+});

--- a/test/components/forward-ref-parameterized.test.ts
+++ b/test/components/forward-ref-parameterized.test.ts
@@ -14,6 +14,7 @@ beforeAll(() => {
 
 test('should detect component which uses forwardRef', () => {
   expect(component.name).toEqual('Focusable');
+  expect(component.types).toEqual({ Ref: {} });
 });
 
 test('should detect default properties from forwardRef', () => {

--- a/test/components/forward-ref.test.ts
+++ b/test/components/forward-ref.test.ts
@@ -14,6 +14,7 @@ beforeAll(() => {
 
 test('should detect component which uses forwardRef', () => {
   expect(component.name).toEqual('Focusable');
+  expect(component.types).toEqual({ Ref: {} });
 });
 
 test('should detect default properties from forwardRef', () => {

--- a/test/components/import-types.test.ts
+++ b/test/components/import-types.test.ts
@@ -4,16 +4,16 @@ import { expect, test, beforeAll } from 'vitest';
 import { buildProject } from './test-helpers';
 import { ComponentDefinition } from '../../src';
 
-let main: ComponentDefinition | undefined;
+let main: ComponentDefinition;
 beforeAll(() => {
   const result = buildProject('import-types');
   expect(result.map(component => component.name)).toEqual(['Dependency', 'Main']);
 
-  main = result.find(component => component.name === 'Main');
+  main = result.find(component => component.name === 'Main')!;
 });
 
 test('should resolve object type', () => {
-  expect(main?.properties).toEqual([
+  expect(main.properties).toEqual([
     {
       name: 'variant',
       type: 'string',
@@ -30,7 +30,7 @@ test('should resolve object type', () => {
 });
 
 test('should resolve event detail types', () => {
-  expect(main?.events).toEqual([
+  expect(main.events).toEqual([
     {
       name: 'onChange',
       cancelable: false,

--- a/test/components/simple.test.ts
+++ b/test/components/simple.test.ts
@@ -16,6 +16,7 @@ test('should have correct name, description and release status', () => {
   expect(component.name).toBe('Simple');
   expect(component.description).toEqual('Component-level description');
   expect(component.releaseStatus).toBe('stable');
+  expect(component.types).toEqual({});
 });
 
 test('should have correct properties', () => {


### PR DESCRIPTION
### Notes

This information is needed to reconstruct this namespace in our system of systems exports

```ts
import { ButtonProps as CoreButtonProps } from './core';

export namespace ButtonProps {
  // this syntax does not exist :(
  export * from CoreButtonProps;
}
```

So I have to run code generation based on this data

```ts
export namespace ButtonProps {
  export type Variant = CoreButtonProps.Variant;
  export type IconName = CoreButtonProps.IconName;
  // etc, based on the new `definition.types` object
}
```

### Testing

Failing builds are expected. I checked, all of them are snapshot tests only. 

I will update the snapshots after merge

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
