### PR TITLE
fix: generated type declarations for output files

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -45,7 +45,7 @@ export function writeComponentsDocumentation({ outDir, ...options }: WriteOption
   fs.writeFileSync(
     pathe.join(outDir, 'index.d.ts'),
     `import { ComponentDefinition } from './interfaces';
-const definitions: Record<string, ComponentDefinition>;
+declare const definitions: Record<string, ComponentDefinition>;
 export default definitions;
 `
   );

--- a/test/components/writer.test.ts
+++ b/test/components/writer.test.ts
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { expect, test } from 'vitest';
+import { execSync } from 'node:child_process';
 import fs from 'node:fs';
 import pathe from 'pathe';
 import { getTemporaryDir } from './test-helpers';
@@ -22,4 +23,5 @@ test('should write documentation files into the outDir', async () => {
   expect(definitions).toEqual({
     simple: expect.objectContaining({ name: 'Simple', dashCaseName: 'simple' }),
   });
+  expect(() => execSync('tsc index.d.ts', { cwd: outDir, stdio: 'inherit' })).not.toThrow();
 });


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fixing cause of this revert: https://github.com/cloudscape-design/components/pull/3467

The build error was:

```
error TS1046: Top-level declarations in .d.ts files must start with either a 'declare' or 'export' modifier.
```

Fixed the error and added a test to validate it here in this package build


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
