### PR TITLE
update export declaration

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -46,7 +46,7 @@ export function writeComponentsDocumentation({ outDir, ...options }: WriteOption
     pathe.join(outDir, 'index.d.ts'),
     `import { ComponentDefinition } from './interfaces';
 declare const definitions: Record<string, ComponentDefinition>;
-export default definitions;
+export = definitions;
 `
   );
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Follow up for this: https://github.com/cloudscape-design/documenter/pull/70

The type declaration still does not work when using `"moduleResolution": "node16"` typescript config


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
