### PR TITLE
fix: Prevent very long inline types

### DIFF
--- a/fixtures/components/complex-types/button/index.tsx
+++ b/fixtures/components/complex-types/button/index.tsx
@@ -1,0 +1,36 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import * as React from 'react';
+
+export interface ButtonProps {
+  style: ButtonProps.Style;
+}
+
+export namespace ButtonProps {
+  export interface Style {
+    root?: {
+      background?: {
+        active?: string;
+        default?: string;
+        disabled?: string;
+        hover?: string;
+      };
+      color?: {
+        active?: string;
+        default?: string;
+        disabled?: string;
+        hover?: string;
+      };
+      borderColor?: {
+        active?: string;
+        default?: string;
+        disabled?: string;
+        hover?: string;
+      };
+    };
+  }
+}
+
+export default function Button(props: ButtonProps) {
+  return <div style={{ background: props.style.root?.background?.default }} />;
+}

--- a/src/components/object-definition.ts
+++ b/src/components/object-definition.ts
@@ -35,24 +35,27 @@ export function getObjectDefinition(
     return getUnionTypeDefinition(realTypeName, realType, rawTypeNode, checker);
   }
   if (realType.getProperties().length > 0) {
-    return {
-      type: type,
-      inlineType: {
-        name: realTypeName,
-        type: 'object',
-        properties: realType
-          .getProperties()
-          .map(prop => {
-            const propType = checker.getTypeAtLocation(extractDeclaration(prop));
-            return {
-              name: prop.getName(),
-              type: stringifyType(propType, checker),
-              optional: isOptional(propType),
-            };
-          })
-          .sort((a, b) => a.name.localeCompare(b.name)),
-      },
-    };
+    const properties = realType
+      .getProperties()
+      .map(prop => {
+        const propType = checker.getTypeAtLocation(extractDeclaration(prop));
+        return {
+          name: prop.getName(),
+          type: stringifyType(propType, checker),
+          optional: isOptional(propType),
+        };
+      })
+      .sort((a, b) => a.name.localeCompare(b.name));
+    if (properties.every(prop => prop.type.length < 200)) {
+      return {
+        type: type,
+        inlineType: {
+          name: realTypeName,
+          type: 'object',
+          properties: properties,
+        },
+      };
+    }
   }
   if (realType.getCallSignatures().length > 0) {
     if (realType.getCallSignatures().length > 1) {

--- a/test/components/complex-types.test.ts
+++ b/test/components/complex-types.test.ts
@@ -4,6 +4,7 @@ import { expect, test, beforeAll } from 'vitest';
 import { ComponentDefinition } from '../../src/components/interfaces';
 import { buildProject } from './test-helpers';
 
+let button: ComponentDefinition;
 let buttonGroup: ComponentDefinition;
 let sideNavigation: ComponentDefinition;
 let columnLayout: ComponentDefinition;
@@ -11,9 +12,9 @@ let table: ComponentDefinition;
 
 beforeAll(() => {
   const result = buildProject('complex-types');
-  expect(result).toHaveLength(4);
+  expect(result).toHaveLength(5);
 
-  [buttonGroup, columnLayout, sideNavigation, table] = result;
+  [button, buttonGroup, columnLayout, sideNavigation, table] = result;
 });
 
 test('should have camel and dash-cased names', () => {
@@ -189,6 +190,16 @@ test('should parse string literal type as single-value union', () => {
       name: 'variant',
       description: 'This is variant',
       type: '"icon"',
+      optional: false,
+    },
+  ]);
+});
+
+test('should trim long inline types', () => {
+  expect(button.properties).toEqual([
+    {
+      name: 'style',
+      type: 'ButtonProps.Style',
       optional: false,
     },
   ]);


### PR DESCRIPTION
*Issue #, if available:*

### Notes

Account for this use-case: https://github.com/cloudscape-design/components/blob/96ae8d04234f323f063b0d1a6ec4059c3412fa2a/src/button/interfaces.ts#L224

This object does not print nice in the API documentation and our squad decided that we truncate it for the time being

### Testing

See the failed snapshot tests in dry-run builds. That diff is expected

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
