### PR TITLE
chore: Exposes documentComponents util

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+
 export * from './components/interfaces';
-export { writeComponentsDocumentation } from './components';
+export { documentComponents, writeComponentsDocumentation } from './components';
 export { documentTestUtils } from './test-utils';
 export { writeTestUtilsDocumentation } from './test-utils-new';


### PR DESCRIPTION
The documentComponents util is to be used for snapshot tests on internal APIs that are not meant to be exposed in the api-docs, see: https://github.com/cloudscape-design/chart-components/pull/70.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
