### PR TITLE
feat: Expand long inline types

### DIFF
--- a/src/components/interfaces.ts
+++ b/src/components/interfaces.ts
@@ -63,6 +63,7 @@ export interface ObjectDefinitionProperty {
   name: string;
   optional: boolean;
   type: string;
+  inlineType?: TypeDefinition;
 }
 
 export interface FunctionDefinition {

--- a/src/components/object-definition.ts
+++ b/src/components/object-definition.ts
@@ -38,24 +38,25 @@ export function getObjectDefinition(
     const properties = realType
       .getProperties()
       .map(prop => {
-        const propType = checker.getTypeAtLocation(extractDeclaration(prop));
+        const propNode = extractDeclaration(prop) as ts.PropertyDeclaration;
+        const propType = checker.getTypeAtLocation(propNode);
+        const typeString = stringifyType(propType, checker);
+
         return {
           name: prop.getName(),
-          type: stringifyType(propType, checker),
           optional: isOptional(propType),
+          ...getObjectDefinition(typeString, propType, propNode.type, checker),
         };
       })
       .sort((a, b) => a.name.localeCompare(b.name));
-    if (properties.every(prop => prop.type.length < 200)) {
-      return {
-        type: type,
-        inlineType: {
-          name: realTypeName,
-          type: 'object',
-          properties: properties,
-        },
-      };
-    }
+    return {
+      type: type,
+      inlineType: {
+        name: realTypeName.length < 100 ? realTypeName : 'object',
+        type: 'object',
+        properties: properties,
+      },
+    };
   }
   if (realType.getCallSignatures().length > 0) {
     if (realType.getCallSignatures().length > 1) {

--- a/test/components/__snapshots__/complex-types.test.ts.snap
+++ b/test/components/__snapshots__/complex-types.test.ts.snap
@@ -1,0 +1,128 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`should print long inline types 1`] = `
+[
+  {
+    "analyticsTag": undefined,
+    "defaultValue": undefined,
+    "deprecatedTag": undefined,
+    "description": undefined,
+    "i18nTag": undefined,
+    "inlineType": {
+      "name": "ButtonProps.Style",
+      "properties": [
+        {
+          "inlineType": {
+            "name": "object",
+            "properties": [
+              {
+                "inlineType": {
+                  "name": "object",
+                  "properties": [
+                    {
+                      "name": "active",
+                      "optional": true,
+                      "type": "string",
+                    },
+                    {
+                      "name": "default",
+                      "optional": true,
+                      "type": "string",
+                    },
+                    {
+                      "name": "disabled",
+                      "optional": true,
+                      "type": "string",
+                    },
+                    {
+                      "name": "hover",
+                      "optional": true,
+                      "type": "string",
+                    },
+                  ],
+                  "type": "object",
+                },
+                "name": "background",
+                "optional": true,
+                "type": "{ active?: string | undefined; default?: string | undefined; disabled?: string | undefined; hover?: string | undefined; }",
+              },
+              {
+                "inlineType": {
+                  "name": "object",
+                  "properties": [
+                    {
+                      "name": "active",
+                      "optional": true,
+                      "type": "string",
+                    },
+                    {
+                      "name": "default",
+                      "optional": true,
+                      "type": "string",
+                    },
+                    {
+                      "name": "disabled",
+                      "optional": true,
+                      "type": "string",
+                    },
+                    {
+                      "name": "hover",
+                      "optional": true,
+                      "type": "string",
+                    },
+                  ],
+                  "type": "object",
+                },
+                "name": "borderColor",
+                "optional": true,
+                "type": "{ active?: string | undefined; default?: string | undefined; disabled?: string | undefined; hover?: string | undefined; }",
+              },
+              {
+                "inlineType": {
+                  "name": "object",
+                  "properties": [
+                    {
+                      "name": "active",
+                      "optional": true,
+                      "type": "string",
+                    },
+                    {
+                      "name": "default",
+                      "optional": true,
+                      "type": "string",
+                    },
+                    {
+                      "name": "disabled",
+                      "optional": true,
+                      "type": "string",
+                    },
+                    {
+                      "name": "hover",
+                      "optional": true,
+                      "type": "string",
+                    },
+                  ],
+                  "type": "object",
+                },
+                "name": "color",
+                "optional": true,
+                "type": "{ active?: string | undefined; default?: string | undefined; disabled?: string | undefined; hover?: string | undefined; }",
+              },
+            ],
+            "type": "object",
+          },
+          "name": "root",
+          "optional": true,
+          "type": "{ background?: { active?: string | undefined; default?: string | undefined; disabled?: string | undefined; hover?: string | undefined; } | undefined; color?: { active?: string | undefined; default?: string | undefined; disabled?: string | undefined; hover?: string | undefined; } | undefined; borderColor?: { ...; } |...",
+        },
+      ],
+      "type": "object",
+    },
+    "name": "style",
+    "optional": false,
+    "systemTags": undefined,
+    "type": "ButtonProps.Style",
+    "visualRefreshTag": undefined,
+  },
+]
+`;

--- a/test/components/complex-types.test.ts
+++ b/test/components/complex-types.test.ts
@@ -60,6 +60,17 @@ test('should have correct property types', () => {
             name: 'allItemsSelectionLabel',
             optional: true,
             type: '((data: TableProps.SelectionState<T>) => string)',
+            inlineType: {
+              name: '(data: TableProps.SelectionState<T>) => string',
+              parameters: [
+                {
+                  name: 'data',
+                  type: 'TableProps.SelectionState<T>',
+                },
+              ],
+              returnType: 'string',
+              type: 'function',
+            },
           },
         ],
       },
@@ -149,7 +160,13 @@ test('should properly display string union types', () => {
       {
         name: 'type',
         optional: true,
-        type: '"link" | "link-group" | "expandable-link-group"',
+        type: 'string',
+        inlineType: {
+          name: '"link" | "link-group" | "expandable-link-group"',
+          type: 'union',
+          valueDescriptions: undefined,
+          values: ['link', 'link-group', 'expandable-link-group'],
+        },
       },
     ],
   });
@@ -195,12 +212,6 @@ test('should parse string literal type as single-value union', () => {
   ]);
 });
 
-test('should trim long inline types', () => {
-  expect(button.properties).toEqual([
-    {
-      name: 'style',
-      type: 'ButtonProps.Style',
-      optional: false,
-    },
-  ]);
+test('should print long inline types', () => {
+  expect(button.properties).toMatchSnapshot();
 });


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Follow up for this change https://github.com/cloudscape-design/documenter/pull/76

Make deeply nested inline types properly printed now


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
