### PR TITLE
chore: Adds missing lint-pr workflow

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -1,0 +1,13 @@
+name: Lint PR
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+  merge_group:
+
+jobs:
+  dry-run:
+    uses: cloudscape-design/actions/.github/workflows/lint-pr.yml@main


### PR DESCRIPTION
*Issue #, if available:*

This repo misses the `lint-pr` workflow. This PR adds it.

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
