### PR TITLE
feat: extract generic types and nullable information as separate fields

### DIFF
--- a/fixtures/test-utils/advanced-types/index.ts
+++ b/fixtures/test-utils/advanced-types/index.ts
@@ -8,6 +8,10 @@ export class TestUtilWrapper {
     return [];
   }
 
+  findSomething(): TestUtilWrapper | null {
+    return Math.random() > 0.5 ? new TestUtilWrapper() : null;
+  }
+
   /**
    * Generic arguments
    */

--- a/fixtures/test-utils/exports/cards.ts
+++ b/fixtures/test-utils/exports/cards.ts
@@ -1,0 +1,20 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { ElementWrapper } from './core';
+
+class CardWrapper extends ElementWrapper {
+  findHeader() {
+    return new ElementWrapper();
+  }
+
+  findContent() {
+    return new ElementWrapper();
+  }
+}
+
+export class CardsWrapper extends ElementWrapper {
+  findItems() {
+    return [new CardWrapper(), new CardWrapper()];
+  }
+}

--- a/fixtures/test-utils/exports/index.ts
+++ b/fixtures/test-utils/exports/index.ts
@@ -2,3 +2,4 @@
 // SPDX-License-Identifier: Apache-2.0
 export { AlertWrapper } from './alert';
 export { ButtonWrapper } from './button';
+export { CardsWrapper } from './cards';

--- a/src/components/type-utils.ts
+++ b/src/components/type-utils.ts
@@ -10,6 +10,13 @@ export function isOptional(type: ts.Type) {
   return !!type.types.find(t => t.flags & ts.TypeFlags.Undefined);
 }
 
+export function isNullable(type: ts.Type) {
+  if (!type.isUnionOrIntersection()) {
+    return false;
+  }
+  return !!type.types.find(t => t.flags & ts.TypeFlags.Null);
+}
+
 export function unwrapNamespaceDeclaration(declaration: ts.Declaration | undefined) {
   if (!declaration) {
     return [];
@@ -113,4 +120,17 @@ export function printFlags(flags: number, mapping: Record<number, string>) {
     .filter(([key, value]) => Number(key) & flags)
     .map(([key, value]) => value)
     .join(' | ');
+}
+
+export function extractTypeArguments(type: ts.Type, checker: ts.TypeChecker) {
+  const typeParameters = checker.getTypeArguments(type as ts.TypeReference);
+
+  if (typeParameters.length <= 0) {
+    return { typeName: stringifyType(type, checker) };
+  }
+  const symbol = type.getSymbol();
+  if (!symbol) {
+    throw new Error(`Unknown generic type without symbol: ${stringifyType(type, checker)}`);
+  }
+  return { typeParameters, typeName: symbol.getName() };
 }

--- a/src/test-utils-new/index.ts
+++ b/src/test-utils-new/index.ts
@@ -4,7 +4,7 @@ import fs from 'node:fs';
 import pathe from 'pathe';
 import { bootstrapTypescriptProject } from '../bootstrap/typescript';
 import extractDocumentation from './extractor';
-import { TestUtilsDoc } from '../test-utils/interfaces';
+import { TestUtilsDoc } from './interfaces';
 
 export interface TestUtilsVariantOptions {
   root: string;

--- a/src/test-utils-new/interfaces.ts
+++ b/src/test-utils-new/interfaces.ts
@@ -8,11 +8,17 @@ export interface Parameter {
   defaultValue?: string;
 }
 
+interface TypeArgument {
+  name: string;
+}
+
 export interface TestUtilMethod {
   name: string;
   description?: string;
   returnType?: {
     name: string;
+    isNullable: boolean;
+    typeArguments?: Array<TypeArgument>;
   };
   parameters: Array<Parameter>;
   inheritedFrom?: {

--- a/test/test-utils/__snapshots__/doc-generation.test.ts.snap
+++ b/test/test-utils/__snapshots__/doc-generation.test.ts.snap
@@ -22,7 +22,24 @@ exports[`Generate documentation > deal with more complex types 1`] = `
     "name": "findAll",
     "parameters": [],
     "returnType": {
-      "name": "Array<HTMLElement>",
+      "isNullable": false,
+      "name": "Array",
+      "typeArguments": [
+        {
+          "name": "HTMLElement",
+        },
+      ],
+    },
+  },
+  {
+    "description": undefined,
+    "inheritedFrom": undefined,
+    "name": "findSomething",
+    "parameters": [],
+    "returnType": {
+      "isNullable": true,
+      "name": "TestUtilWrapper",
+      "typeArguments": undefined,
     },
   },
   {
@@ -41,7 +58,9 @@ exports[`Generate documentation > deal with more complex types 1`] = `
       },
     ],
     "returnType": {
+      "isNullable": false,
       "name": "void",
+      "typeArguments": undefined,
     },
   },
   {
@@ -60,7 +79,9 @@ exports[`Generate documentation > deal with more complex types 1`] = `
       },
     ],
     "returnType": {
+      "isNullable": false,
       "name": "void",
+      "typeArguments": undefined,
     },
   },
   {
@@ -79,7 +100,9 @@ exports[`Generate documentation > deal with more complex types 1`] = `
       },
     ],
     "returnType": {
+      "isNullable": false,
       "name": "void",
+      "typeArguments": undefined,
     },
   },
 ]

--- a/test/test-utils/doc-generation.test.ts
+++ b/test/test-utils/doc-generation.test.ts
@@ -19,14 +19,14 @@ describe('Generate documentation', () => {
 
     const noOpMethod = methods.find(method => method.name === 'noOp');
     expect(noOpMethod).toBeDefined();
-    expect(noOpMethod?.returnType).toEqual({ name: 'void' });
+    expect(noOpMethod?.returnType).toEqual({ name: 'void', isNullable: false });
     expect(noOpMethod?.parameters).toEqual([]);
     expect(noOpMethod?.description).toBeUndefined();
     expect(noOpMethod?.inheritedFrom).toBeUndefined();
 
     const findStringMethod = methods.find(method => method.name === 'findString');
     expect(findStringMethod).toBeDefined();
-    expect(findStringMethod?.returnType).toEqual({ name: 'string' });
+    expect(findStringMethod?.returnType).toEqual({ name: 'string', isNullable: false });
     expect(findStringMethod?.parameters).toEqual([]);
     expect(findStringMethod?.description).toBe(
       'Finds a string.\n\nThe function may look trivial but people have been losing their words\nsince centuries.'
@@ -35,14 +35,14 @@ describe('Generate documentation', () => {
 
     const setStringMethod = methods.find(method => method.name === 'setString');
     expect(setStringMethod).toBeDefined();
-    expect(setStringMethod?.returnType).toEqual({ name: 'void' });
+    expect(setStringMethod?.returnType).toEqual({ name: 'void', isNullable: false });
     expect(setStringMethod?.parameters).toMatchSnapshot();
     expect(setStringMethod?.description).toBe('Short Text');
     expect(setStringMethod?.inheritedFrom).toBeUndefined();
 
     const findObjectMethod = methods.find(method => method.name === 'findObject');
     expect(findObjectMethod).toBeDefined();
-    expect(findObjectMethod?.returnType).toEqual({ name: 'TestReturnType' });
+    expect(findObjectMethod?.returnType).toEqual({ name: 'TestReturnType', isNullable: false });
     expect(findObjectMethod?.parameters).toEqual([]);
     expect(findObjectMethod?.description).toBe('Short Text.\n\nLong Text.');
     expect(findObjectMethod?.inheritedFrom).toBeUndefined();
@@ -57,7 +57,7 @@ describe('Generate documentation', () => {
     expect(classDoc.name).toBe('TestUtilWrapper');
 
     const methods = classDoc.methods;
-    expect(methods.length).toBe(4);
+    expect(methods.length).toBe(5);
     expect(methods).toMatchSnapshot();
   });
 
@@ -85,11 +85,13 @@ describe('Generate documentation', () => {
 
   test('deal with re-exports', () => {
     const results = buildTestUtilsProject('exports');
-    expect(results.map(classDoc => classDoc.name)).toEqual(['AlertWrapper', 'ButtonWrapper']);
+    expect(results.map(classDoc => classDoc.name)).toEqual(['AlertWrapper', 'ButtonWrapper', 'CardsWrapper']);
     const alertWrapper = results.find(classDoc => classDoc.name === 'AlertWrapper')!;
     expect(alertWrapper.methods.map(method => method.name)).toEqual(['findContent']);
     const buttonWrapper = results.find(classDoc => classDoc.name === 'ButtonWrapper')!;
     expect(buttonWrapper.methods.map(method => method.name)).toEqual(['findText']);
+    const cardsWrapper = results.find(classDoc => classDoc.name === 'CardsWrapper')!;
+    expect(cardsWrapper.methods.map(method => method.name)).toEqual(['findItems']);
   });
 
   test('default value rendering', () => {
@@ -110,7 +112,7 @@ describe('Generate documentation', () => {
             defaultValue: "'first'",
           },
         ],
-        returnType: { name: 'void' },
+        returnType: { name: 'void', isNullable: false },
       },
       {
         name: 'openDropdown',
@@ -122,7 +124,7 @@ describe('Generate documentation', () => {
             defaultValue: 'false',
           },
         ],
-        returnType: { name: 'void' },
+        returnType: { name: 'void', isNullable: false },
       },
       {
         name: 'selectOption',
@@ -134,7 +136,7 @@ describe('Generate documentation', () => {
             defaultValue: '1',
           },
         ],
-        returnType: { name: 'void' },
+        returnType: { name: 'void', isNullable: false },
       },
     ]);
   });

--- a/test/test-utils/test-helpers.ts
+++ b/test/test-utils/test-helpers.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { documentTestUtilsNew, TestUtilsVariantOptions } from '../../src/test-utils-new';
-import { TestUtilsDoc } from '../../src/test-utils/interfaces';
+import { TestUtilsDoc } from '../../src/test-utils-new/interfaces';
 
 export function buildTestUtilsProject(
   name: string,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Compatibility with the old test-utils-doc generator
1. Support `typeArguments` field
2. Add new `isNullable` field to avoid manual parsing `type.name.split(' | ')` on the website end

*Testing*

Expected to fail snapshot tests downstream, already prepared an update: https://github.com/cloudscape-design/test-utils/pull/98

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
