### PR TITLE
fix: MultiElementWrapper support

### DIFF
--- a/fixtures/test-utils/exports/core.ts
+++ b/fixtures/test-utils/exports/core.ts
@@ -1,3 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 export class ElementWrapper {}
+
+// this generic type simulates MultiElementWrapper from test-utils-core
+export class MultiElementWrapper<T extends ElementWrapper> {}

--- a/fixtures/test-utils/exports/index.ts
+++ b/fixtures/test-utils/exports/index.ts
@@ -5,3 +5,4 @@ export { AlertWrapper };
 export { ButtonWrapper } from './button';
 export { CardsWrapper } from './cards';
 export { DropdownWrapper } from './dropdown';
+export { RadioGroupWrapper } from './radio-group';

--- a/fixtures/test-utils/exports/radio-group.ts
+++ b/fixtures/test-utils/exports/radio-group.ts
@@ -1,0 +1,16 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { ElementWrapper, MultiElementWrapper } from './core';
+
+class RadioButtonWrapper extends ElementWrapper {
+  findLabel() {
+    return new ElementWrapper();
+  }
+}
+
+export class RadioGroupWrapper extends ElementWrapper {
+  findItems() {
+    return new MultiElementWrapper<RadioButtonWrapper>();
+  }
+}

--- a/src/test-utils-new/extractor.ts
+++ b/src/test-utils-new/extractor.ts
@@ -134,7 +134,7 @@ function findDependencyType(
   }
 
   const typeName = checker.symbolToString(symbol);
-  if (typeName === 'Array') {
+  if (typeName === 'Array' || typeName === 'MultiElementWrapper') {
     const itemType = checker.getTypeArguments(type as ts.TypeReference)[0];
     return findDependencyType(itemType, checker);
   }

--- a/test/test-utils/__snapshots__/doc-generation.test.ts.snap
+++ b/test/test-utils/__snapshots__/doc-generation.test.ts.snap
@@ -108,139 +108,180 @@ exports[`Generate documentation > deal with more complex types 1`] = `
 ]
 `;
 
-exports[`Generate documentation > deal with re-exports > alert wrapper methods 1`] = `
+exports[`Generate documentation > deal with re-exports 1`] = `
 [
   {
-    "description": undefined,
-    "inheritedFrom": undefined,
-    "name": "findContent",
-    "parameters": [],
-    "returnType": {
-      "isNullable": false,
-      "name": "ElementWrapper",
-      "typeArguments": undefined,
-    },
-  },
-]
-`;
-
-exports[`Generate documentation > deal with re-exports > button wrapper methods 1`] = `
-[
-  {
-    "description": undefined,
-    "inheritedFrom": undefined,
-    "name": "findText",
-    "parameters": [],
-    "returnType": {
-      "isNullable": false,
-      "name": "ElementWrapper",
-      "typeArguments": undefined,
-    },
-  },
-]
-`;
-
-exports[`Generate documentation > deal with re-exports > card item wrapper methods 1`] = `
-[
-  {
-    "description": undefined,
-    "inheritedFrom": undefined,
-    "name": "findContent",
-    "parameters": [],
-    "returnType": {
-      "isNullable": false,
-      "name": "ElementWrapper",
-      "typeArguments": undefined,
-    },
-  },
-  {
-    "description": undefined,
-    "inheritedFrom": undefined,
-    "name": "findHeader",
-    "parameters": [],
-    "returnType": {
-      "isNullable": false,
-      "name": "ElementWrapper",
-      "typeArguments": undefined,
-    },
-  },
-]
-`;
-
-exports[`Generate documentation > deal with re-exports > cards wrapper methods 1`] = `
-[
-  {
-    "description": undefined,
-    "inheritedFrom": undefined,
-    "name": "findItems",
-    "parameters": [],
-    "returnType": {
-      "isNullable": false,
-      "name": "Array",
-      "typeArguments": [
-        {
-          "name": "CardWrapper",
+    "methods": [
+      {
+        "description": undefined,
+        "inheritedFrom": undefined,
+        "name": "findContent",
+        "parameters": [],
+        "returnType": {
+          "isNullable": false,
+          "name": "ElementWrapper",
+          "typeArguments": undefined,
         },
-      ],
-    },
-  },
-]
-`;
-
-exports[`Generate documentation > deal with re-exports > dropdown wrapper methods 1`] = `
-[
-  {
-    "description": undefined,
-    "inheritedFrom": undefined,
-    "name": "findHighlightedOption",
-    "parameters": [],
-    "returnType": {
-      "isNullable": false,
-      "name": "OptionWrapper",
-      "typeArguments": undefined,
-    },
+      },
+    ],
+    "name": "AlertWrapper",
   },
   {
-    "description": undefined,
-    "inheritedFrom": undefined,
-    "name": "findItemGroup",
-    "parameters": [],
-    "returnType": {
-      "isNullable": false,
-      "name": "DropdownWrapper",
-      "typeArguments": undefined,
-    },
+    "methods": [
+      {
+        "description": undefined,
+        "inheritedFrom": undefined,
+        "name": "findText",
+        "parameters": [],
+        "returnType": {
+          "isNullable": false,
+          "name": "ElementWrapper",
+          "typeArguments": undefined,
+        },
+      },
+    ],
+    "name": "ButtonWrapper",
   },
   {
-    "description": undefined,
-    "inheritedFrom": undefined,
-    "name": "findItems",
-    "parameters": [],
-    "returnType": {
-      "isNullable": false,
-      "name": "Array",
-      "typeArguments": [
-        {
+    "methods": [
+      {
+        "description": undefined,
+        "inheritedFrom": undefined,
+        "name": "findItems",
+        "parameters": [],
+        "returnType": {
+          "isNullable": false,
+          "name": "Array",
+          "typeArguments": [
+            {
+              "name": "CardWrapper",
+            },
+          ],
+        },
+      },
+    ],
+    "name": "CardsWrapper",
+  },
+  {
+    "methods": [
+      {
+        "description": undefined,
+        "inheritedFrom": undefined,
+        "name": "findContent",
+        "parameters": [],
+        "returnType": {
+          "isNullable": false,
+          "name": "ElementWrapper",
+          "typeArguments": undefined,
+        },
+      },
+      {
+        "description": undefined,
+        "inheritedFrom": undefined,
+        "name": "findHeader",
+        "parameters": [],
+        "returnType": {
+          "isNullable": false,
+          "name": "ElementWrapper",
+          "typeArguments": undefined,
+        },
+      },
+    ],
+    "name": "CardWrapper",
+  },
+  {
+    "methods": [
+      {
+        "description": undefined,
+        "inheritedFrom": undefined,
+        "name": "findHighlightedOption",
+        "parameters": [],
+        "returnType": {
+          "isNullable": false,
           "name": "OptionWrapper",
+          "typeArguments": undefined,
         },
-      ],
-    },
+      },
+      {
+        "description": undefined,
+        "inheritedFrom": undefined,
+        "name": "findItemGroup",
+        "parameters": [],
+        "returnType": {
+          "isNullable": false,
+          "name": "DropdownWrapper",
+          "typeArguments": undefined,
+        },
+      },
+      {
+        "description": undefined,
+        "inheritedFrom": undefined,
+        "name": "findItems",
+        "parameters": [],
+        "returnType": {
+          "isNullable": false,
+          "name": "Array",
+          "typeArguments": [
+            {
+              "name": "OptionWrapper",
+            },
+          ],
+        },
+      },
+    ],
+    "name": "DropdownWrapper",
   },
-]
-`;
-
-exports[`Generate documentation > deal with re-exports > option wrapper methods 1`] = `
-[
   {
-    "description": undefined,
-    "inheritedFrom": undefined,
-    "name": "findLabel",
-    "parameters": [],
-    "returnType": {
-      "isNullable": true,
-      "name": "ElementWrapper",
-      "typeArguments": undefined,
-    },
+    "methods": [
+      {
+        "description": undefined,
+        "inheritedFrom": undefined,
+        "name": "findLabel",
+        "parameters": [],
+        "returnType": {
+          "isNullable": true,
+          "name": "ElementWrapper",
+          "typeArguments": undefined,
+        },
+      },
+    ],
+    "name": "OptionWrapper",
+  },
+  {
+    "methods": [
+      {
+        "description": undefined,
+        "inheritedFrom": undefined,
+        "name": "findItems",
+        "parameters": [],
+        "returnType": {
+          "isNullable": false,
+          "name": "MultiElementWrapper",
+          "typeArguments": [
+            {
+              "name": "RadioButtonWrapper",
+            },
+          ],
+        },
+      },
+    ],
+    "name": "RadioGroupWrapper",
+  },
+  {
+    "methods": [
+      {
+        "description": undefined,
+        "inheritedFrom": undefined,
+        "name": "findLabel",
+        "parameters": [],
+        "returnType": {
+          "isNullable": false,
+          "name": "ElementWrapper",
+          "typeArguments": undefined,
+        },
+      },
+    ],
+    "name": "RadioButtonWrapper",
   },
 ]
 `;

--- a/test/test-utils/doc-generation.test.ts
+++ b/test/test-utils/doc-generation.test.ts
@@ -92,19 +92,10 @@ describe('Generate documentation', () => {
       'CardWrapper',
       'DropdownWrapper',
       'OptionWrapper',
+      'RadioGroupWrapper',
+      'RadioButtonWrapper',
     ]);
-    const alertWrapper = results.find(classDoc => classDoc.name === 'AlertWrapper')!;
-    expect(alertWrapper.methods).toMatchSnapshot('alert wrapper methods');
-    const buttonWrapper = results.find(classDoc => classDoc.name === 'ButtonWrapper')!;
-    expect(buttonWrapper.methods).toMatchSnapshot('button wrapper methods');
-    const cardsWrapper = results.find(classDoc => classDoc.name === 'CardsWrapper')!;
-    expect(cardsWrapper.methods).toMatchSnapshot('cards wrapper methods');
-    const cardItemWrapper = results.find(classDoc => classDoc.name === 'CardWrapper')!;
-    expect(cardItemWrapper.methods).toMatchSnapshot('card item wrapper methods');
-    const dropdownWrapper = results.find(classDoc => classDoc.name === 'DropdownWrapper')!;
-    expect(dropdownWrapper.methods).toMatchSnapshot('dropdown wrapper methods');
-    const optionWrapper = results.find(classDoc => classDoc.name === 'OptionWrapper')!;
-    expect(optionWrapper.methods).toMatchSnapshot('option wrapper methods');
+    expect(results).toMatchSnapshot();
   });
 
   test('default value rendering', () => {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fixing a bug where `RadioButtonWrapper` is not included into the final documentation output, because it is only used as a part of `MultiElementWrapper<RadioButtonWrapper>` generic type


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
