### PR TITLE
chore: switch to @tony.ganchev/eslint-plugin-header

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,7 +3,7 @@
 
 import { includeIgnoreFile } from '@eslint/compat';
 import eslint from '@eslint/js';
-import headerPlugin from 'eslint-plugin-header';
+import headerPlugin from '@tony.ganchev/eslint-plugin-header';
 import eslintPrettier from 'eslint-plugin-prettier/recommended';
 import reactPlugin from 'eslint-plugin-react';
 import unicornPlugin from 'eslint-plugin-unicorn';

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
       },
       "devDependencies": {
         "@eslint/compat": "^1.2.9",
+        "@tony.ganchev/eslint-plugin-header": "^3.3.1",
         "@types/micromatch": "^4.0.1",
         "@types/node": "^20.0.0",
         "@types/react": "^16.14.8",
@@ -21,7 +22,6 @@
         "@vitest/coverage-v8": "^3.1.3",
         "eslint": "^9.20.1",
         "eslint-config-prettier": "^10.1.5",
-        "eslint-plugin-header": "^3.1.1",
         "eslint-plugin-prettier": "^5.2.3",
         "eslint-plugin-react": "^7.31.11",
         "eslint-plugin-unicorn": "^60.0.0",
@@ -1236,6 +1236,16 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@tony.ganchev/eslint-plugin-header": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@tony.ganchev/eslint-plugin-header/-/eslint-plugin-header-3.3.1.tgz",
+      "integrity": "sha512-/Fj0+DaXbBfrlXmd3wBZkB8TIwGT3N++y/oTYxRABK/gzNxjgcBjt63xBpuHCYIXmH1EwuALd6XS1fzNG4S0zg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "eslint": ">=7.7.0"
+      }
     },
     "node_modules/@types/braces": {
       "version": "3.0.5",
@@ -2935,16 +2945,6 @@
       },
       "peerDependencies": {
         "eslint": ">=7.0.0"
-      }
-    },
-    "node_modules/eslint-plugin-header": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-header/-/eslint-plugin-header-3.1.1.tgz",
-      "integrity": "sha512-9vlKxuJ4qf793CmeeSrZUvVClw6amtpghq3CuWcB5cUNnWHQhgcqy5eF8oVKFk1G3Y/CbchGfEaw3wiIJaNmVg==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "eslint": ">=7.7.0"
       }
     },
     "node_modules/eslint-plugin-prettier": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "prepare": "husky"
   },
   "devDependencies": {
+    "@tony.ganchev/eslint-plugin-header": "^3.3.1",
     "@types/micromatch": "^4.0.1",
     "@types/node": "^20.0.0",
     "@types/react": "^16.14.8",
@@ -27,7 +28,6 @@
     "eslint": "^9.20.1",
     "@eslint/compat": "^1.2.9",
     "eslint-config-prettier": "^10.1.5",
-    "eslint-plugin-header": "^3.1.1",
     "eslint-plugin-prettier": "^5.2.3",
     "eslint-plugin-react": "^7.31.11",
     "eslint-plugin-unicorn": "^60.0.0",


### PR DESCRIPTION
Hi, team,

I noticed you are using _eslint-plugin-header_ with the schema-turn-off
workaround to support ESLint 9.

I forked _@tony.ganchev/eslint-plugin-header_ mid-2024 to address this
issue and hoped it would be a temporary measure but since the original
has not been updated for five years I decided to continue improving the
new plugin and have been doing so for the last two years.

Specific improvements include:
- full JSON schema for validating the configuration.
- fixed multiple bugs with the behavior of the plugin on Windows.
- many other bug-fixes.
- improved autofixing and error-reporting behavior.
- added support for leading pragma comments before the header such as
  `@jest-environment`.

I've sent PR proposals to other projects in the cloudscape-design space:
- https://github.com/cloudscape-design/board-components/pull/401
- https://github.com/cloudscape-design/browser-test-tools/pull/188
- https://github.com/cloudscape-design/build-tools/pull/38
- https://github.com/cloudscape-design/chart-components/pull/185
- https://github.com/cloudscape-design/chat-components/pull/121
- https://github.com/cloudscape-design/code-view/pull/122
- https://github.com/cloudscape-design/collection-hooks/pull/136
- https://github.com/cloudscape-design/component-toolkit/pull/200
- https://github.com/cloudscape-design/components/pull/4308
- https://github.com/cloudscape-design/demos/pull/243
- https://github.com/cloudscape-design/global-styles/pull/73
- https://github.com/cloudscape-design/jest-preset/pull/58
- https://github.com/cloudscape-design/theming-core/pull/148
- https://github.com/cloudscape-design/test-utils/pull/114

Looking forward to your feedback.