### PR TITLE
feat: allow children region to opt out of the default slot

### DIFF
--- a/fixtures/components/is-children-default-tag/example/index.tsx
+++ b/fixtures/components/is-children-default-tag/example/index.tsx
@@ -1,0 +1,16 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import * as React from 'react';
+
+export interface ExampleProps {
+  /**
+   * Main content
+   * @displayname content
+   * @isChildrenDefault false
+   */
+  children?: React.ReactNode;
+}
+
+export default function Example({ children }: ExampleProps) {
+  return <div>{children}</div>;
+}

--- a/fixtures/components/is-children-default-tag/tsconfig.json
+++ b/fixtures/components/is-children-default-tag/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["./**/*.tsx"]
+}

--- a/src/components/component-definition.ts
+++ b/src/components/component-definition.ts
@@ -65,7 +65,8 @@ export function buildComponentDefinition(
         name: region.name,
         displayName: getCommentTag(region.description, 'displayname'),
         description: region.description.text,
-        isDefault: region.name === 'children',
+        // The `children` prop is the default slot, unless it opts out with @isChildrenDefault false.
+        isDefault: region.name === 'children' && getCommentTag(region.description, 'isChildrenDefault') !== 'false',
         systemTags: getCommentTags(region.description, 'awsuiSystem'),
         visualRefreshTag: getCommentTag(region.description, 'visualrefresh'),
         deprecatedTag: getCommentTag(region.description, 'deprecated'),

--- a/test/components/is-children-default-tag.test.ts
+++ b/test/components/is-children-default-tag.test.ts
@@ -1,0 +1,26 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { expect, test, beforeAll } from 'vitest';
+import { ComponentDefinition } from '../../src/components/interfaces';
+import { buildProject } from './test-helpers';
+
+let component: ComponentDefinition;
+beforeAll(() => {
+  const result = buildProject('is-children-default-tag');
+  expect(result).toHaveLength(1);
+
+  component = result[0];
+});
+
+test('children region opts out of the default slot with @isChildrenDefault false', () => {
+  expect(component.regions).toEqual([
+    {
+      name: 'children',
+      displayName: 'content',
+      description: 'Main content',
+      isDefault: false,
+      deprecatedTag: undefined,
+      visualRefreshTag: undefined,
+    },
+  ]);
+});


### PR DESCRIPTION
The documenter marks any `children` region as the default slot (`isDefault: true`). Consumers such as the components website use that flag to render a "(default)" label and a generic "Default slot: Specify the content as a child of the component." note in the API docs.

For some components, such as top navigation, that annotation is misleading: `children` may be one of several supported ways to provide content rather than the single canonical default slot. Until now there was no way to express that, since `isDefault` was hardcoded to `region.name === 'children'`.

This adds an `@isChildrenDefault` JSDoc tag on a region so a component can opt its `children` slot out of the default-slot treatment, while keeping the existing behavior for everyone who does not use the tag.

Behavior:
- `children`, no tag                    -> isDefault: true  (unchanged)
- `children` + @isChildrenDefault false -> isDefault: false
- any non-`children` region             -> isDefault: false (unchanged)

Usage:

```typescript
  export interface TopNavigationProps {
    /**
     * Specifies custom navigation content.
     * @displayname content * @isChildrenDefault false
     */
     children?: React.ReactNode;
   }
```

Adds the `is-children-default-tag` fixture and a test covering the opt-out case.

*Issue #, if available:* 1qZFXQh4o49s (pippin)

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
