### PR TITLE
chore: Remediate 2 Dependabot security alerts (lockfile only)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1079,9 +1079,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1572,9 +1572,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3079,9 +3079,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4694,10 +4694,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
-      "dev": true,
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -4710,7 +4709,8 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
+      },
+      "dev": true
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -5099,10 +5099,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
-      "dev": true,
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "funding": [
         {
           "type": "opencollective",
@@ -5119,13 +5118,14 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
-      }
+      },
+      "dev": true
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -6834,6 +6834,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/vitest/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     }
   }


### PR DESCRIPTION
## Automated Dependabot security-alert remediation

Alert-driven remediation of this repository's **open** Dependabot security alerts.
Baseline: `5c84a544e` on `main`.

### Alerts resolved (2 of 2)

| Alert | Sev | Package | Major line | Vulnerable range | First patched | Now resolved to | Advisory |
|---|---|---|---|---|---|---|---|
| #55 | high | `brace-expansion` | 1.x | `< 1.1.16` | 1.1.16 | `2.1.4, 1.1.18` | [GHSA-3jxr-9vmj-r5cp](https://github.com/advisories/GHSA-3jxr-9vmj-r5cp) (CVE-2026-13149) |
| #56 | high | `postcss` | 8.x | `<= 8.5.17` | 8.5.18 | `8.5.25` | [GHSA-r28c-9q8g-f849](https://github.com/advisories/GHSA-r28c-9q8g-f849) (—) |

### How this was remediated

* **Rung 1 — `npm audit fix --package-lock-only --ignore-scripts`** (no `--force` was used anywhere in this run).
* The repo's own `prepare-package-lock` convention (`postinstall` in `@cloudscape-design/build-tools`) was applied afterwards, so no `@cloudscape-design/*` entries are (re-)introduced into the lockfile.
* npm's full reconciliation additionally healed unrelated pre-existing lockfile drift (stale entries, `dev`/`optional` flags, unrelated minor bumps). **That collateral was deliberately discarded**: only the security-relevant entries from npm's computed result were applied on top of the committed lockfile, so this diff contains alert-driven changes only.
* Verified with `npm ls --package-lock-only --all`: **zero new** unmet/invalid dependency problems versus `main`.

### Lockfile changes (6)

| Package | From | To | Scope | Lockfile path |
|---|---|---|---|---|
| `brace-expansion` | 2.0.3 | 2.1.4 | dev | `node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion` |
| `brace-expansion` | 1.1.13 | 1.1.18 | dev | `node_modules/brace-expansion` |
| `brace-expansion` | 2.0.3 | 2.1.4 | dev | `node_modules/glob/node_modules/brace-expansion` |
| `nanoid` | 3.3.12 | 3.3.16 | dev | `node_modules/nanoid` |
| `postcss` | 8.5.15 | 8.5.25 | dev | `node_modules/postcss` |
| `yaml` | (new) | 2.9.0 | dev | `node_modules/vitest/node_modules/yaml` |

### NPMPM (NpmPrettyMuch) availability — internal build safety

**Not applicable — 0 non-dev dependencies changed.** Every version bump in this PR is `dev: true`, which the NPMPM availability check skips, so there is no internal-build (Brazil) impact and the check should come back green.

### Does merging clear this repository's alert list?

**Yes.** Merging this PR is expected to close **all 2** of this repository's currently-open Dependabot security alerts.

---

<sub>Existing Dependabot-authored PRs were deliberately **not** touched, reviewed, rebased, or closed by this run.</sub>

> Opened by roko-dependabot on behalf of @ernst-dev. Alert-driven remediation; not merged — a human must review and merge.
